### PR TITLE
Preview popover fixes

### DIFF
--- a/src/Timelive.ts
+++ b/src/Timelive.ts
@@ -136,10 +136,13 @@ export class Timelive {
   }
 
   private createPopover(marker: HTMLElement): HTMLElement {
-    const popover = marker.createDiv({
+    const popover = document.body.createDiv({
       cls: "tlv-popup popover hover-popover",
     });
     marker.onmouseover = marker.ontouchstart = () => {
+      const { x, y } = this.getPopoverPosition(marker);
+      popover.style.left = `${x}px`;
+      popover.style.top = `${y}px`;
       popover.style.display = "block";
     };
     marker.onmouseout = marker.ontouchend = () => {
@@ -217,5 +220,12 @@ export class Timelive {
       this.splitYears(years, average, b, level + 1);
     }
     return years;
+  }
+
+  private getPopoverPosition(marker: HTMLElement): { x: number; y: number } {
+    const rect = marker.getBoundingClientRect();
+    const x = rect.left + globalThis.scrollX;
+    const y = rect.top + globalThis.scrollY + marker.offsetHeight;
+    return { x, y };
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,6 +63,10 @@ export default class TimelivePlugin extends Plugin {
     this.addSettingTab(new TimeliveSettingTab(this.app, this));
   }
 
+  override onunload() {
+    document.body.findAll("tlv-popup popover hover-popover").forEach((el) => el.remove());
+  }
+
   async loadSettings() {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
   }


### PR DESCRIPTION
- Fixes #4: timeline markers appear over the preview popover
- Fixes #3: preview aren't displaying when the note is embedded
- Clean up on plugin unloading